### PR TITLE
Remove deprecated lines from .husky/pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged --concurrent false


### PR DESCRIPTION
Otherwise, husky warns that these lines will eventually stop working.