### PR TITLE
Replace matrix-js-sdk's MatrixEvent with our own representation

### DIFF
--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -4,10 +4,7 @@
 
 ```ts
 
-import { EventStatus } from 'matrix-js-sdk';
-import { IEventRelation } from 'matrix-js-sdk';
 import { JSX } from 'react';
-import { Membership } from 'matrix-js-sdk';
 import { ModuleApi } from '@matrix-org/react-sdk-module-api';
 import { Root } from 'react-dom/client';
 import { RuntimeModule } from '@matrix-org/react-sdk-module-api';
@@ -146,21 +143,15 @@ export interface MatrixEvent {
     // (undocumented)
     eventId: string;
     // (undocumented)
-    membership?: Membership;
-    // (undocumented)
     originServerTs: number;
     // (undocumented)
     redacts?: string;
-    // (undocumented)
-    relation?: IEventRelation | null;
     // (undocumented)
     roomId?: string;
     // (undocumented)
     sender: string;
     // (undocumented)
     stateKey?: string;
-    // (undocumented)
-    status: EventStatus;
     // (undocumented)
     type: string;
     // (undocumented)

--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -22,6 +22,7 @@ export interface AliasCustomisations {
 export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiExtension {
     readonly config: ConfigApi;
     createRoot(element: Element): Root;
+    // @alpha
     readonly customComponents: CustomComponentsApi;
     readonly i18n: I18nApi;
     readonly rootNode: HTMLElement;
@@ -59,11 +60,8 @@ export interface ConfigApi {
     get<K extends keyof Config = never>(key?: K): Config | Config[K];
 }
 
-// @public
+// @alpha
 export interface CustomComponentsApi {
-    // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "MatrixEvent" which is marked as @beta
-    // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "CustomMessageRenderFunction" which is marked as @alpha
-    // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "CustomMessageRenderHints" which is marked as @alpha
     registerMessageRenderer(eventTypeOrFilter: string | ((mxEvent: MatrixEvent) => boolean), renderer: CustomMessageRenderFunction, hints?: CustomMessageRenderHints): void;
 }
 
@@ -134,27 +132,15 @@ export interface LifecycleCustomisations {
     onLoggedOutAndStorageCleared?(): void;
 }
 
-// @beta
+// @alpha
 export interface MatrixEvent {
-    // (undocumented)
-    age?: number;
-    // (undocumented)
     content: Record<string, unknown>;
-    // (undocumented)
     eventId: string;
-    // (undocumented)
     originServerTs: number;
-    // (undocumented)
-    redacts?: string;
-    // (undocumented)
-    roomId?: string;
-    // (undocumented)
+    roomId: string;
     sender: string;
-    // (undocumented)
     stateKey?: string;
-    // (undocumented)
     type: string;
-    // (undocumented)
     unsigned: Record<string, unknown>;
 }
 

--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import { EventStatus } from 'matrix-js-sdk';
+import { IEventRelation } from 'matrix-js-sdk';
 import { JSX } from 'react';
-import { MatrixEvent } from 'matrix-js-sdk/lib/matrix';
+import { Membership } from 'matrix-js-sdk';
 import { ModuleApi } from '@matrix-org/react-sdk-module-api';
 import { Root } from 'react-dom/client';
 import { RuntimeModule } from '@matrix-org/react-sdk-module-api';
@@ -62,6 +64,7 @@ export interface ConfigApi {
 
 // @public
 export interface CustomComponentsApi {
+    // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "MatrixEvent" which is marked as @beta
     // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "CustomMessageRenderFunction" which is marked as @alpha
     // Warning: (ae-incompatible-release-tags) The symbol "registerMessageRenderer" is marked as @public, but its signature references "CustomMessageRenderHints" which is marked as @alpha
     registerMessageRenderer(eventTypeOrFilter: string | ((mxEvent: MatrixEvent) => boolean), renderer: CustomMessageRenderFunction, hints?: CustomMessageRenderHints): void;
@@ -132,6 +135,36 @@ export interface LegacyModuleApiExtension {
 export interface LifecycleCustomisations {
     // (undocumented)
     onLoggedOutAndStorageCleared?(): void;
+}
+
+// @beta
+export interface MatrixEvent {
+    // (undocumented)
+    age?: number;
+    // (undocumented)
+    content: Record<string, unknown>;
+    // (undocumented)
+    eventId: string;
+    // (undocumented)
+    membership?: Membership;
+    // (undocumented)
+    originServerTs: number;
+    // (undocumented)
+    redacts?: string;
+    // (undocumented)
+    relation?: IEventRelation | null;
+    // (undocumented)
+    roomId?: string;
+    // (undocumented)
+    sender: string;
+    // (undocumented)
+    stateKey?: string;
+    // (undocumented)
+    status: EventStatus;
+    // (undocumented)
+    type: string;
+    // (undocumented)
+    unsigned: Record<string, unknown>;
 }
 
 // @alpha @deprecated (undocumented)

--- a/packages/element-web-module-api/package.json
+++ b/packages/element-web-module-api/package.json
@@ -38,7 +38,6 @@
         "@types/react-dom": "^19.0.4",
         "@types/semver": "^7.5.8",
         "@vitest/coverage-v8": "^3.0.4",
-        "matrix-js-sdk": "^37.5.0",
         "matrix-web-i18n": "^3.3.0",
         "semver": "^7.6.3",
         "typescript": "^5.7.3",
@@ -51,7 +50,6 @@
         "@matrix-org/react-sdk-module-api": "*",
         "@types/react": "*",
         "@types/react-dom": "*",
-        "matrix-js-sdk": "*",
         "matrix-web-i18n": "*",
         "react": "^19"
     },

--- a/packages/element-web-module-api/src/api/custom-components.ts
+++ b/packages/element-web-module-api/src/api/custom-components.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { JSX } from "react";
-import type { MatrixEvent } from "matrix-js-sdk/lib/matrix";
+import type { MatrixEvent } from "../models/event";
 
 /**
  * Properties for all message components.

--- a/packages/element-web-module-api/src/api/custom-components.ts
+++ b/packages/element-web-module-api/src/api/custom-components.ts
@@ -48,7 +48,7 @@ export type CustomMessageRenderHints = {
 
 /**
  * Function used to render a message component.
- * @alpha Unlikely to change
+ * @alpha Subject to change.
  */
 export type CustomMessageRenderFunction = (
     /**
@@ -63,7 +63,7 @@ export type CustomMessageRenderFunction = (
 
 /**
  * API for inserting custom components into Element.
- * @public
+ * @alpha Subject to change.
  */
 export interface CustomComponentsApi {
     /**

--- a/packages/element-web-module-api/src/api/index.ts
+++ b/packages/element-web-module-api/src/api/index.ts
@@ -90,7 +90,7 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
 
     /**
      * The custom message component API.
-     * @public
+     * @alpha
      */
     readonly customComponents: CustomComponentsApi;
     /**

--- a/packages/element-web-module-api/src/index.ts
+++ b/packages/element-web-module-api/src/index.ts
@@ -9,6 +9,7 @@ export { ModuleLoader, ModuleIncompatibleError } from "./loader";
 export type { Api, Module, ModuleFactory } from "./api";
 export type { Config, ConfigApi } from "./api/config";
 export type { I18nApi, Variables, Translations } from "./api/i18n";
+export type * from "./models/event";
 export type * from "./api/custom-components";
 export type * from "./api/legacy-modules";
 export type * from "./api/legacy-customisations";

--- a/packages/element-web-module-api/src/models/event.ts
+++ b/packages/element-web-module-api/src/models/event.ts
@@ -1,3 +1,10 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
 /**
  * Representation of a Matrix event.
  * @beta

--- a/packages/element-web-module-api/src/models/event.ts
+++ b/packages/element-web-module-api/src/models/event.ts
@@ -1,5 +1,3 @@
-import type { EventStatus, IEventRelation, Membership } from "matrix-js-sdk";
-
 /**
  * Representation of a Matrix event.
  * @beta
@@ -14,8 +12,5 @@ export interface MatrixEvent {
     stateKey?: string;
     originServerTs: number;
     redacts?: string;
-    membership?: Membership;
-    status: EventStatus;
-    relation?: IEventRelation | null;
     age?: number;
 }

--- a/packages/element-web-module-api/src/models/event.ts
+++ b/packages/element-web-module-api/src/models/event.ts
@@ -1,0 +1,24 @@
+import type { EventStatus, IEventRelation, Membership } from "matrix-js-sdk";
+
+/**
+ * Representation of a Matrix event.
+ * @beta
+ */
+export interface MatrixEvent {
+    // Properties provided by the spec
+    eventId: string;
+    roomId?: string;
+    sender: string;
+    content: Record<string, unknown>;
+    unsigned: Record<string, unknown>;
+    type: string;
+    stateKey?: string;
+    originServerTs: number;
+    redacts?: string;
+
+    // Properties provided by the SDK
+    membership?: Membership;
+    status: EventStatus;
+    relation?: IEventRelation | null;
+    age?: number;
+}

--- a/packages/element-web-module-api/src/models/event.ts
+++ b/packages/element-web-module-api/src/models/event.ts
@@ -5,7 +5,6 @@ import type { EventStatus, IEventRelation, Membership } from "matrix-js-sdk";
  * @beta
  */
 export interface MatrixEvent {
-    // Properties provided by the spec
     eventId: string;
     roomId?: string;
     sender: string;
@@ -15,8 +14,6 @@ export interface MatrixEvent {
     stateKey?: string;
     originServerTs: number;
     redacts?: string;
-
-    // Properties provided by the SDK
     membership?: Membership;
     status: EventStatus;
     relation?: IEventRelation | null;

--- a/packages/element-web-module-api/src/models/event.ts
+++ b/packages/element-web-module-api/src/models/event.ts
@@ -6,18 +6,43 @@ Please see LICENSE files in the repository root for full details.
 */
 
 /**
- * Representation of a Matrix event.
- * @beta
+ * Representation of a Matrix event, as specified by the client server specification.
+ * @alpha Subject to change.
+ * @see https://spec.matrix.org/v1.14/client-server-api/#room-event-format
  */
 export interface MatrixEvent {
+    /**
+     * The event ID of this event.
+     */
     eventId: string;
-    roomId?: string;
+    /**
+     * The room ID which contains this event.
+     */
+    roomId: string;
+    /**
+     * The Matrix ID of the user who sent this event.
+     */
     sender: string;
+    /**
+     * The content of the event.
+     * If the event was encrypted, this is the decrypted content.
+     */
     content: Record<string, unknown>;
+    /**
+     * Contains optional extra information about the event.
+     */
     unsigned: Record<string, unknown>;
+    /**
+     * The type of the event.
+     */
     type: string;
+    /**
+     * The state key of the event.
+     * If this key is set, including `""` then the event is a state event.
+     */
     stateKey?: string;
+    /**
+     * Timestamp (in milliseconds since the unix epoch) on originating homeserver when this event was sent.
+     */
     originServerTs: number;
-    redacts?: string;
-    age?: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,11 +369,6 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.12.5":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
-  integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
-
 "@babel/template@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
@@ -932,16 +927,6 @@
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
-
-"@matrix-org/matrix-sdk-crypto-wasm@^14.0.1":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.1.0.tgz#843574ab3e3408162acf1af62e7d0e919e7fb871"
-  integrity sha512-vcSxHJIr6lP0Fgo8jl0sTHg+OZxZn+skGjiyB62erfgw/R2QqJl0ZVSY8SRcbk9LtHo/ZGld1tnaOyjL2e3cLQ==
-
-"@matrix-org/olm@3.2.15":
-  version "3.2.15"
-  resolved "https://registry.yarnpkg.com/@matrix-org/olm/-/olm-3.2.15.tgz#55f3c1b70a21bbee3f9195cecd6846b1083451ec"
-  integrity sha512-S7lOrndAK9/8qOtaTq/WhttJC/o4GAzdfK0MUPpo8ApzsJEC0QjtwrkC3KBXdFP1cD1MXi/mlKR7aaoVMKgs6Q==
 
 "@matrix-org/react-sdk-module-api@^2.0.0", "@matrix-org/react-sdk-module-api@^2.2.1", "@matrix-org/react-sdk-module-api@^2.3.0", "@matrix-org/react-sdk-module-api@^2.5.0":
   version "2.5.0"
@@ -1774,11 +1759,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/events@^3.0.0":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.3.tgz#a8ef894305af28d1fc6d2dfdfc98e899591ea529"
-  integrity sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1847,11 +1827,6 @@
   integrity sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==
   dependencies:
     csstype "^3.0.2"
-
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/semver@^7.5.8":
   version "7.5.8"
@@ -2273,11 +2248,6 @@ alien-signals@^0.4.9:
   resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-0.4.14.tgz#9ff8f72a272300a51692f54bd9bbbada78fbf539"
   integrity sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==
 
-another-json@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz#b5f4019c973b6dd5c6506a2d93469cb6d32aeedc"
-  integrity sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==
-
 ansi-escapes@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.0.0.tgz#00fc19f491bbb18e1d481b97868204f92109bfe7"
@@ -2576,11 +2546,6 @@ bare-stream@^2.0.0:
   dependencies:
     streamx "^2.21.0"
 
-base-x@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
-  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
-
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2718,13 +2683,6 @@ browserslist@^4.24.0, browserslist@^4.24.3:
     electron-to-chromium "^1.5.73"
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
-
-bs58@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
-  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
-  dependencies:
-    base-x "^5.0.0"
 
 buffer-crc32@^1.0.0:
   version "1.0.0"
@@ -2995,11 +2953,6 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==
-
-content-type@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
-  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -3871,7 +3824,7 @@ eventemitter3@^5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
-events@^3.0.0, events@^3.2.0, events@^3.3.0:
+events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -4860,11 +4813,6 @@ jsonfile@^6.0.1:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-jwt-decode@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
-  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
-
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -5018,11 +4966,6 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loglevel@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
-  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
-
 long@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.1.tgz#9d4222d3213f38a5ec809674834e0f0ab21abe96"
@@ -5106,32 +5049,6 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-matrix-events-sdk@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
-  integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
-
-matrix-js-sdk@^37.5.0:
-  version "37.5.0"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-37.5.0.tgz#026ff984bbdf825060a30aa8d1eae0e2f7f93daf"
-  integrity sha512-5tyuAi5hnKud1UkVq8Z2/3c22hWGELBZzErJPZkE6Hju2uGUfGtrIx6uj6puv0ZjvsUU3X6Qgm8vdReKO1PGig==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@matrix-org/matrix-sdk-crypto-wasm" "^14.0.1"
-    "@matrix-org/olm" "3.2.15"
-    another-json "^0.2.0"
-    bs58 "^6.0.0"
-    content-type "^1.0.4"
-    jwt-decode "^4.0.0"
-    loglevel "^1.9.2"
-    matrix-events-sdk "0.0.1"
-    matrix-widget-api "^1.10.0"
-    oidc-client-ts "^3.0.1"
-    p-retry "4"
-    sdp-transform "^2.14.1"
-    unhomoglyph "^1.0.6"
-    uuid "11"
-
 matrix-web-i18n@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/matrix-web-i18n/-/matrix-web-i18n-3.3.0.tgz#a9f9d87d18ef96f75171883abbf201952cbfbe22"
@@ -5142,14 +5059,6 @@ matrix-web-i18n@^3.3.0:
     lodash "^4.17.21"
     minimist "^1.2.8"
     walk "^2.3.15"
-
-matrix-widget-api@^1.10.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.1.tgz#5b1caeed2fc58148bcd2984e0546d2d06a1713ad"
-  integrity sha512-mkOHUVzaN018TCbObfGOSaMW2GoUxOfcxNNlTVx5/HeMk3OSQPQM0C9oEME5Liiv/dBUoSrEB64V8wF7e/gb1w==
-  dependencies:
-    "@types/events" "^3.0.0"
-    events "^3.2.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5466,13 +5375,6 @@ object.values@^1.1.6, object.values@^1.2.0, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-oidc-client-ts@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-3.2.1.tgz#d71d899dc0cddd11a8b84e41265fd79d7e0f152a"
-  integrity sha512-hS5AJ5s/x4bXhHvNJT1v+GGvzHUwdRWqNQQbSrp10L1IRmzfRGKQ3VWN3dstJb+oF3WtAyKezwD2+dTEIyBiAA==
-  dependencies:
-    jwt-decode "^4.0.0"
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5554,14 +5456,6 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
-
-p-retry@4:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
-  dependencies:
-    "@types/retry" "0.12.0"
-    retry "^0.13.1"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -6143,11 +6037,6 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
 
-retry@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
-
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -6266,11 +6155,6 @@ scheduler@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
   integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
-
-sdp-transform@^2.14.1:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/sdp-transform/-/sdp-transform-2.15.0.tgz#79d37a2481916f36a0534e07b32ceaa87f71df42"
-  integrity sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.2"
@@ -7079,11 +6963,6 @@ undici@^7.10.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.10.0.tgz#8ae17a976acc6593b13c9ff3342840bea9b24670"
   integrity sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==
 
-unhomoglyph@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/unhomoglyph/-/unhomoglyph-1.0.6.tgz#ea41f926d0fcf598e3b8bb2980c2ddac66b081d3"
-  integrity sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==
-
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -7142,11 +7021,6 @@ util@^0.12.4, util@^0.12.5:
     is-generator-function "^1.0.7"
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
-
-uuid@11:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
Fixes the flaw in https://github.com/element-hq/element-web/pull/30074 whereby due to differing imports of the matrix-js-sdk, it's not possible to (safely) pass the type from Element Web to a module. In line with us thinking about the future with Rust SDKs, this changes the module API to use it's own SDK neutral interface.

**This is a backwards incompatible change. We are marking the Custom Message Components API as alpha stability due to the potential for further changes, and will adjust in the future.**

Companion commit is https://github.com/element-hq/element-web/pull/30074/commits/66e73818a8ce03b9224053f35fa1b331db380c31