### PR TITLE
Add branding API (title only)

### DIFF
--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -31,7 +31,6 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
 
 // @public (undocumented)
 export interface BrandApi {
-    registerFaviconRenderer(renderFunction: FaviconRenderFunction): void;
     registerTitleRenderer(renderFunction: TitleRenderFunction): void;
 }
 
@@ -92,15 +91,6 @@ export interface DirectoryCustomisations {
     // (undocumented)
     requireCanonicalAliasAccessToPublish?(): boolean;
 }
-
-// @public
-export type FaviconRenderFunction = (opts: FaviconRenderOptions) => string;
-
-// @public
-export type FaviconRenderOptions = {
-    notificationCount?: number;
-    errorDidOccur: boolean;
-};
 
 // @public
 export interface I18nApi {

--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -20,12 +20,19 @@ export interface AliasCustomisations {
 //
 // @public
 export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiExtension {
+    readonly brand: BrandApi;
     readonly config: ConfigApi;
     createRoot(element: Element): Root;
     // @alpha
     readonly customComponents: CustomComponentsApi;
     readonly i18n: I18nApi;
     readonly rootNode: HTMLElement;
+}
+
+// @public (undocumented)
+export interface BrandApi {
+    registerFaviconRenderer(renderFunction: FaviconRenderFunction): void;
+    registerTitleRenderer(renderFunction: TitleRenderFunction): void;
 }
 
 // @alpha @deprecated (undocumented)
@@ -85,6 +92,15 @@ export interface DirectoryCustomisations {
     // (undocumented)
     requireCanonicalAliasAccessToPublish?(): boolean;
 }
+
+// @public
+export type FaviconRenderFunction = (opts: FaviconRenderOptions) => string;
+
+// @public
+export type FaviconRenderOptions = {
+    notificationCount?: number;
+    errorDidOccur: boolean;
+};
 
 // @public
 export interface I18nApi {
@@ -228,6 +244,18 @@ export interface RoomListCustomisations<Room> {
 
 // @alpha @deprecated (undocumented)
 export type RuntimeModuleConstructor = new (api: ModuleApi) => RuntimeModule;
+
+// @public
+export type TitleRenderFunction = (opts: TitleRenderOptions) => string;
+
+// @public
+export type TitleRenderOptions = {
+    notificationCount?: number;
+    errorDidOccur?: boolean;
+    roomId?: string;
+    roomName?: string;
+    notificationsEnabled?: boolean;
+};
 
 // @public
 export type Translations = Record<string, {

--- a/packages/element-web-module-api/src/api/brand.ts
+++ b/packages/element-web-module-api/src/api/brand.ts
@@ -1,0 +1,84 @@
+/**
+ * Options to be used when rendering a favicon. This represents
+ * the state of the application.
+ * @public
+ */
+export type FaviconRenderOptions = {
+    /**
+     * The number of unread notifications the user has. May be undefined if the notification count isn't known yet (such as during initial loading).
+     */
+    notificationCount?: number;
+    /**
+     * Has an error occured (e.g. failure to sync) and should be represented in the favicon's badge.
+     */
+    errorDidOccur: boolean;
+};
+
+/**
+ * Options to be used when rendering a favicon. This represents
+ * the state of the application.
+ * @public
+ */
+export type TitleRenderOptions = {
+    /**
+     * The number of unread notifications the user has.
+     */
+    notificationCount?: number;
+    /**
+     * Has an error occured (e.g. failure to sync) and should be represented in the favicon's badge.
+     */
+    errorDidOccur?: boolean;
+    /**
+     * The current room ID, if one is open.
+     */
+    roomId?: string;
+    /**
+     * The current room name, if one is open.
+     */
+    roomName?: string;
+
+    /**
+     * Does the user have notifications enabled globally.
+     */
+    notificationsEnabled?: boolean;
+};
+
+/**
+ * Function to render the favicon.
+ * @public
+ * @param opts - Current state of the client.
+ * @returns The URL of the badge to be rendered.
+ *          If you are rendering to a canvas, you can use a Data URL here.
+ */
+export type FaviconRenderFunction = (opts: FaviconRenderOptions) => string;
+
+/**
+ * Function to render the window title.
+ * @public
+ * @param opts - Current state of the client.
+ * @returns The text to be rendered.
+ */
+export type TitleRenderFunction = (opts: TitleRenderOptions) => string;
+
+/**
+ * @public
+ */
+export interface BrandApi {
+    /**
+     * Register a function to render a favicon. This function will be called whenever
+     * the application needs to re-render the icon.
+     * @public
+     * @param renderFunction - The function to use to render.
+     * @throws If another module has registered a favicon renderer, this will throw.
+     */
+    registerFaviconRenderer(renderFunction: FaviconRenderFunction): void;
+
+    /**
+     * Register a function to render the window title. This function will be called whenever
+     * the application needs to re-render the title of the browser window.
+     * @public
+     * @param renderFunction - The function to use to render.
+     * @throws If another module has registered a title renderer, this will throw.
+     */
+    registerTitleRenderer(renderFunction: TitleRenderFunction): void;
+}

--- a/packages/element-web-module-api/src/api/brand.ts
+++ b/packages/element-web-module-api/src/api/brand.ts
@@ -1,5 +1,12 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
 /**
- * Options to be used when rendering a favicon. This represents
+ * Options to be used when rendering the window title. This represents
  * the state of the application.
  * @public
  */
@@ -9,7 +16,7 @@ export type TitleRenderOptions = {
      */
     notificationCount?: number;
     /**
-     * Has an error occured (e.g. failure to sync) and should be represented in the favicon's badge.
+     * Has an error occured (e.g. failure to sync).
      */
     errorDidOccur?: boolean;
     /**

--- a/packages/element-web-module-api/src/api/brand.ts
+++ b/packages/element-web-module-api/src/api/brand.ts
@@ -3,22 +3,6 @@
  * the state of the application.
  * @public
  */
-export type FaviconRenderOptions = {
-    /**
-     * The number of unread notifications the user has. May be undefined if the notification count isn't known yet (such as during initial loading).
-     */
-    notificationCount?: number;
-    /**
-     * Has an error occured (e.g. failure to sync) and should be represented in the favicon's badge.
-     */
-    errorDidOccur: boolean;
-};
-
-/**
- * Options to be used when rendering a favicon. This represents
- * the state of the application.
- * @public
- */
 export type TitleRenderOptions = {
     /**
      * The number of unread notifications the user has.
@@ -44,15 +28,6 @@ export type TitleRenderOptions = {
 };
 
 /**
- * Function to render the favicon.
- * @public
- * @param opts - Current state of the client.
- * @returns The URL of the badge to be rendered.
- *          If you are rendering to a canvas, you can use a Data URL here.
- */
-export type FaviconRenderFunction = (opts: FaviconRenderOptions) => string;
-
-/**
  * Function to render the window title.
  * @public
  * @param opts - Current state of the client.
@@ -64,15 +39,6 @@ export type TitleRenderFunction = (opts: TitleRenderOptions) => string;
  * @public
  */
 export interface BrandApi {
-    /**
-     * Register a function to render a favicon. This function will be called whenever
-     * the application needs to re-render the icon.
-     * @public
-     * @param renderFunction - The function to use to render.
-     * @throws If another module has registered a favicon renderer, this will throw.
-     */
-    registerFaviconRenderer(renderFunction: FaviconRenderFunction): void;
-
     /**
      * Register a function to render the window title. This function will be called whenever
      * the application needs to re-render the title of the browser window.

--- a/packages/element-web-module-api/src/api/index.ts
+++ b/packages/element-web-module-api/src/api/index.ts
@@ -100,6 +100,7 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
      * @public
      */
     readonly brand: BrandApi;
+
     /**
      * Create a ReactDOM root for rendering React components.
      * Exposed to allow modules to avoid needing to bundle their own ReactDOM.

--- a/packages/element-web-module-api/src/api/index.ts
+++ b/packages/element-web-module-api/src/api/index.ts
@@ -11,6 +11,7 @@ import { LegacyCustomisationsApiExtension } from "./legacy-customisations";
 import { ConfigApi } from "./config";
 import { I18nApi } from "./i18n";
 import { CustomComponentsApi } from "./custom-components";
+import { BrandApi } from "./brand";
 
 /**
  * Module interface for modules to implement.
@@ -93,6 +94,12 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
      * @alpha
      */
     readonly customComponents: CustomComponentsApi;
+
+    /**
+     * The brand API.
+     * @public
+     */
+    readonly brand: BrandApi;
     /**
      * Create a ReactDOM root for rendering React components.
      * Exposed to allow modules to avoid needing to bundle their own ReactDOM.

--- a/packages/element-web-module-api/src/index.ts
+++ b/packages/element-web-module-api/src/index.ts
@@ -11,5 +11,6 @@ export type { Config, ConfigApi } from "./api/config";
 export type { I18nApi, Variables, Translations } from "./api/i18n";
 export type * from "./models/event";
 export type * from "./api/custom-components";
+export type * from "./api/brand";
 export type * from "./api/legacy-modules";
 export type * from "./api/legacy-customisations";


### PR DESCRIPTION
This adds simple hooks for modules to provide their own favicon (including badging) and window title.