### PR TITLE
Add message hint to prevent media from being downloaded.

### DIFF
--- a/packages/element-web-module-api/element-web-module-api.api.md
+++ b/packages/element-web-module-api/element-web-module-api.api.md
@@ -78,6 +78,7 @@ originalComponent?: (props?: OriginalComponentProps) => React.JSX.Element) => JS
 // @alpha
 export type CustomMessageRenderHints = {
     allowEditingEvent?: boolean;
+    allowDownloadingMedia?: boolean | Promise<boolean>;
 };
 
 // @alpha @deprecated (undocumented)

--- a/packages/element-web-module-api/src/api/custom-components.ts
+++ b/packages/element-web-module-api/src/api/custom-components.ts
@@ -44,6 +44,12 @@ export type CustomMessageRenderHints = {
      * Default is true.
      */
     allowEditingEvent?: boolean;
+    /**
+     * If an event contains media, this function will be called to check
+     * if the media can be prompted to be downloaded as a file.
+     * Default is true.
+     */
+    allowDownloadingMedia?: (mxEvent: MatrixEvent) => Promise<boolean>;
 };
 
 /**


### PR DESCRIPTION
This is a relatively trivial hint to prevent the download button from appearing near media when a module forbids it. Should be used in conjunction with a custom component to prevent displaying media, as otherwise it's easy to circumvent. Takes a Promise as some applications for this would require an async request before allowing downloading to take place.