### PR TITLE
Fix the MAS config override ordering

### DIFF
--- a/packages/element-web-playwright-common/package.json
+++ b/packages/element-web-playwright-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-playwright-common",
     "type": "module",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "license": "SEE LICENSE IN README.md",
     "repository": {
         "type": "git",

--- a/packages/element-web-playwright-common/src/testcontainers/mas.ts
+++ b/packages/element-web-playwright-common/src/testcontainers/mas.ts
@@ -186,9 +186,9 @@ export class MatrixAuthenticationServiceContainer extends GenericContainer {
         const port = await getFreePort();
 
         this.config.http = {
+            ...this.config.http,
             public_base: `http://localhost:${port}/`,
             issuer: `http://localhost:${port}/`,
-            ...this.config.http,
         };
 
         this.withExposedPorts({


### PR DESCRIPTION
That was a bug introduced in https://github.com/element-hq/element-modules/pull/46

It fails with

```
Error: relative URL without a base: "" for key "default.http.issuer" in config/config.yaml YAML file
```