### PR TITLE
Playwright: add a `createNewInstance` utility function

### DIFF
--- a/packages/element-web-playwright-common/src/index.ts
+++ b/packages/element-web-playwright-common/src/index.ts
@@ -12,6 +12,7 @@ import { test as base } from "./fixtures/index.js";
 import { routeConfigJson } from "./utils/config_json.js";
 
 export * from "./utils/config_json.js";
+export * from "./utils/context.js";
 
 export { populateLocalStorageWithCredentials } from "./fixtures/user.js";
 

--- a/packages/element-web-playwright-common/src/utils/context.ts
+++ b/packages/element-web-playwright-common/src/utils/context.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { Browser } from "playwright-core";
+import { Page } from "@playwright/test";
+
+import { Credentials } from "./api.js";
+import { Config } from "../index.js";
+import { routeConfigJson } from "./config_json.js";
+import { populateLocalStorageWithCredentials } from "../fixtures/user.js";
+
+/** Create a new instance of the application, in a separate browser context, using the given credentials.
+ *
+ * @param browser - the browser to use
+ * @param credentials - the credentials to use for the new instance
+ * @param additionalConfig - additional config for the `config.json` for the new instance
+ * @param labsFlags - additional labs flags for the `config.json` for the new instance
+ * @param disablePresence - whether to disable presence for the new instance
+ */
+export async function createNewInstance(
+    browser: Browser,
+    credentials: Credentials,
+    additionalConfig: Partial<Config> = {},
+    labsFlags: string[] = [],
+    disablePresence: boolean = false,
+): Promise<Page> {
+    const context = await browser.newContext();
+    await routeConfigJson(context, credentials.homeserverBaseUrl, additionalConfig, labsFlags, disablePresence);
+    const page = await context.newPage();
+    await populateLocalStorageWithCredentials(page, credentials);
+    await page.goto("/");
+    await page.waitForSelector(".mx_MatrixChat", { timeout: 30000 });
+    return page;
+}


### PR DESCRIPTION
Sometimes it's useful to be able to use two separate Element-Web instances, in isolated browsers. This patch adds a utility method which creates such an instance.

~~Based on #81~~