### PR TITLE
element-web-playwright-common: bump version to 2.0.0

### DIFF
--- a/packages/element-web-playwright-common/package.json
+++ b/packages/element-web-playwright-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-playwright-common",
     "type": "module",
-    "version": "1.4.6",
+    "version": "2.0.0",
     "license": "SEE LICENSE IN README.md",
     "repository": {
         "type": "git",


### PR DESCRIPTION
(`Credentials` has added a new field, which is potentially a breaking change)