### PR TITLE
Restricted Guests Synapse module: Fix the `check_codestyle` tox job by bumping `flake8` from `4.0.1` -> `7.3.0`

### DIFF
--- a/modules/restricted-guests/synapse/setup.cfg
+++ b/modules/restricted-guests/synapse/setup.cfg
@@ -35,7 +35,7 @@ dev =
   pydantic == 2.4.2
   # for linting
   black == 22.3.0
-  flake8 == 4.0.1
+  flake8 == 7.3.0
   isort == 5.9.3
 
 


### PR DESCRIPTION
Otherwise we get this cryptic error when trying to lint the Restricted Guests Synapse module:

```
➜ tox -e check_codestyle
.pkg: _optional_hooks> python /home/work/code/element-modules/.venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_sdist> python /home/work/code/element-modules/.venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_wheel> python /home/work/code/element-modules/.venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: prepare_metadata_for_build_wheel> python /home/work/code/element-modules/.venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_sdist> python /home/work/code/element-modules/.venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
check_codestyle: recreate env because dependencies removed: flake8==7.1.1
check_codestyle: remove tox env folder /home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle
check_codestyle: install_package_deps> python -I -m pip install aiounittest attrs black==22.3.0 coverage flake8==4.0.1 isort==5.9.3 matrix-synapse mypy==1.10.0 parameterized pydantic==2.4.2 tox twisted
check_codestyle: install_package> python -I -m pip install --force-reinstall --no-deps /home/work/code/element-modules/modules/restricted-guests/synapse/.tox/.tmp/package/63/synapse_guest_module-1.0.0.tar.gz
check_codestyle: commands[0]> flake8 synapse_guest_module tests
Traceback (most recent call last):
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/bin/flake8", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/main/application.py", line 375, in run
    self._run(argv)
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/main/application.py", line 363, in _run
    self.initialize(argv)
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/main/application.py", line 343, in initialize
    self.find_plugins(config_finder)
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/main/application.py", line 157, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/plugins/manager.py", line 363, in __init__
    self.manager = PluginManager(
                   ^^^^^^^^^^^^^^
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/plugins/manager.py", line 243, in __init__
    self._load_entrypoint_plugins()
  File "/home/work/code/element-modules/modules/restricted-guests/synapse/.tox/check_codestyle/lib/python3.12/site-packages/flake8/plugins/manager.py", line 261, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
check_codestyle: exit 1 (0.09 seconds) /home/work/code/element-modules/modules/restricted-guests/synapse> flake8 synapse_guest_module tests pid=3205348
  check_codestyle: FAIL code 1 (30.23=setup[30.14]+cmd[0.09] seconds)
  evaluation failed :( (30.25 seconds)
```

Bumping the `flake8` version fixes this, with no code style changes needed.