### PR TITLE
Fix css injection not working on `lockLeftPanelWidth` fixture

### DIFF
--- a/packages/element-web-playwright-common/package.json
+++ b/packages/element-web-playwright-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-playwright-common",
     "type": "module",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "license": "SEE LICENSE IN README.md",
     "repository": {
         "type": "git",

--- a/packages/element-web-playwright-common/src/fixtures/panel.ts
+++ b/packages/element-web-playwright-common/src/fixtures/panel.ts
@@ -6,7 +6,7 @@
  */
 import { test as base } from "./services.js";
 
-export interface TestFixtures {
+export const test = base.extend<{
     /**
      * Whether the left panel should have its width fixed.
      * This is done because the library that we use for rendering collapsible
@@ -17,8 +17,6 @@ export interface TestFixtures {
      * behaviour.
      */
     lockLeftPanelWidth: boolean;
-}
-
-export const test = base.extend<TestFixtures>({
+}>({
     lockLeftPanelWidth: true,
 });

--- a/packages/element-web-playwright-common/src/fixtures/panel.ts
+++ b/packages/element-web-playwright-common/src/fixtures/panel.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+import { test as base } from "./services.js";
+
+export interface TestFixtures {
+    /**
+     * Whether the left panel should have its width fixed.
+     * This is done because the library that we use for rendering collapsible
+     * panels uses math to calculate the width which can sometimes leads to +/-1px
+     * difference. While this does not matter to the user, it can lead to screenshot
+     * tests failing.
+     * Defaults to true, should be set to false via {@link base.use} when you want to test the collapse
+     * behaviour.
+     */
+    lockLeftPanelWidth: boolean;
+}
+
+export const test = base.extend<TestFixtures>({
+    lockLeftPanelWidth: true,
+});

--- a/packages/element-web-playwright-common/src/fixtures/user.ts
+++ b/packages/element-web-playwright-common/src/fixtures/user.ts
@@ -9,7 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import { type Page } from "@playwright/test";
 import { sample, uniqueId } from "lodash-es";
 
-import { test as base } from "./services.js";
+import { test as base } from "./panel.js";
 import { type Credentials } from "../utils/api.js";
 
 /** Adds an initScript to the given page which will populate localStorage appropriately so that Element will use the given credentials. */
@@ -93,9 +93,18 @@ export const test = base.extend<{
         await use(page);
     },
 
-    user: async ({ pageWithCredentials: page, credentials }, use) => {
+    user: async ({ pageWithCredentials: page, credentials, lockLeftPanelWidth }, use) => {
         await page.goto("/");
         await page.waitForSelector(".mx_MatrixChat", { timeout: 30000 });
+        if (lockLeftPanelWidth) {
+            await page.addStyleTag({
+                content: `
+                        #left-panel {
+                            flex: 0 0 369.6875px !important;
+                        }
+                `,
+            });
+        }
         await use(credentials);
     },
 });

--- a/packages/element-web-playwright-common/src/index.ts
+++ b/packages/element-web-playwright-common/src/index.ts
@@ -66,16 +66,6 @@ export interface TestFixtures {
 
     labsFlags: string[];
     disablePresence: boolean;
-    /**
-     * Whether the left panel should have its width fixed.
-     * This is done because the library that we use for rendering collapsible
-     * panels uses math to calculate the width which can sometimes leads to +/-1px
-     * difference. While this does not matter to the user, it can lead to screenshot
-     * tests failing.
-     * Defaults to true, should be set to false via {@link base.use} when you want to test the collapse
-     * behaviour.
-     */
-    lockLeftPanelWidth: boolean;
 }
 
 export const test = base.extend<TestFixtures>({
@@ -83,18 +73,8 @@ export const test = base.extend<TestFixtures>({
     config: async ({}, use) => use({}),
     labsFlags: async ({}, use) => use([]),
     disablePresence: async ({}, use) => use(false),
-    lockLeftPanelWidth: true,
-    page: async ({ homeserver, context, page, config, labsFlags, disablePresence, lockLeftPanelWidth }, use) => {
+    page: async ({ homeserver, context, page, config, labsFlags, disablePresence }, use) => {
         await routeConfigJson(context, homeserver.baseUrl, config, labsFlags, disablePresence);
-        if (lockLeftPanelWidth) {
-            await page.addStyleTag({
-                content: `
-                        #left-panel {
-                            flex: 0 0 369.6875px !important;
-                        }
-                `,
-            });
-        }
         await use(page);
     },
 });


### PR DESCRIPTION
https://github.com/element-hq/element-modules/pull/228 added the css injection on the page fixture. But this would get overwritten when the app is loaded (`page.goto("/")`). The right place to do the css injection is when running the user fixture.