### PR TITLE
Use the rejectToast function from utils instead of a fixture

### DIFF
--- a/modules/widget-lifecycle/element-web/e2e/widget-lifecycle.spec.ts
+++ b/modules/widget-lifecycle/element-web/e2e/widget-lifecycle.spec.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type SynapseContainer } from "@element-hq/element-web-playwright-common/lib/testcontainers/index.js";
+import { rejectToastIfExists } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../../../playwright/element-web-test.ts";
 
@@ -63,8 +64,8 @@ test.describe("Widget Lifecycle", () => {
             },
         });
 
-        test("auto-approves preload and identity", async ({ page, user, homeserver, toasts }, testInfo) => {
-            toasts.rejectToastIfExists("Verify this device");
+        test("auto-approves preload and identity", async ({ page, user, homeserver }, testInfo) => {
+            rejectToastIfExists(page, "Verify this device");
 
             // A bot creates a room with the widget pinned to the top panel, then invites the test user.
             // Because the widget was added by a different user (the bot), Element would normally show a
@@ -121,8 +122,8 @@ test.describe("Widget Lifecycle", () => {
             ).toBeVisible();
         });
 
-        test("prompts for capabilities not in the allowlist", async ({ page, user, homeserver, toasts }, testInfo) => {
-            toasts.rejectToastIfExists("Verify this device");
+        test("prompts for capabilities not in the allowlist", async ({ page, user, homeserver }, testInfo) => {
+            rejectToastIfExists(page, "Verify this device");
 
             const bot = await homeserver.registerUser(`bot_${testInfo.testId}`, "password", "Bot");
             const { room_id: roomId } = await homeserver.csApi.request<{ room_id: string }>(
@@ -184,9 +185,8 @@ test.describe("Widget Lifecycle", () => {
             page,
             user,
             homeserver,
-            toasts,
         }, testInfo) => {
-            toasts.rejectToastIfExists("Verify this device");
+            rejectToastIfExists(page, "Verify this device");
 
             const bot = await homeserver.registerUser(`bot_${testInfo.testId}`, "password", "Bot");
             const { room_id: roomId } = await homeserver.csApi.request<{ room_id: string }>(

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@action-validator/cli": "^0.6.0",
         "@action-validator/core": "^0.6.0",
         "@element-hq/element-web-module-api": "1.13.0",
-        "@element-hq/element-web-playwright-common": "^4.0.0",
+        "@element-hq/element-web-playwright-common": "^4.1.0",
         "@playwright/test": "^1.52.0",
         "@stylistic/eslint-plugin": "^5.0.0",
         "@types/node": "^22.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,16 +550,16 @@
   resolved "https://registry.yarnpkg.com/@element-hq/element-web-module-api/-/element-web-module-api-1.13.0.tgz#a3e9af978ea07e7f2e3b25f7c55877bf890fff6e"
   integrity sha512-3QXejLpXHK52e/BM61zeFQt1pnmKEfhFsooKI3OOXa5M9io683q1eA986TquZTDHoorm0Q+4TyxjYD3j2Nkp8A==
 
-"@element-hq/element-web-playwright-common@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@element-hq/element-web-playwright-common/-/element-web-playwright-common-4.0.0.tgz#3448df530f1d7d8c1268bc5c75cb86e3f36a70f6"
-  integrity sha512-EQ68nmcXbwxif4W9QMi0l3loFmi1bDsXk3If15X+R2uZ3HVrcB7M7TMhpVgeMEpOu3YOYqFbT3ZrmaM4GlMSRg==
+"@element-hq/element-web-playwright-common@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@element-hq/element-web-playwright-common/-/element-web-playwright-common-4.1.0.tgz#2b8c980a6cc9bc8463f8013d7f3e8cc5d07df4cf"
+  integrity sha512-qwgK2TEml7G4Pc8B1zhyCcRypAPhzxEKnJmz37QTLkO4LGotACpdI9CyD61jVgXwf4uY8z0+afED1Eky5AMcXA==
   dependencies:
     "@axe-core/playwright" "^4.10.1"
     "@testcontainers/postgresql" "^11.0.0"
     glob "^13.0.5"
     lodash-es "^4.17.23"
-    mailpit-api "^1.2.0"
+    mailpit-api "^2.0.0"
     strip-ansi "^7.1.0"
     testcontainers "^11.0.0"
     wait-on "^9.0.4"
@@ -2817,7 +2817,7 @@ axe-core@~4.11.1:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.1.tgz#052ff9b2cbf543f5595028b583e4763b40c78ea7"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
 
-axios@^1.13.5, axios@^1.15.0:
+axios@^1.15.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
@@ -4104,11 +4104,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-event-target-polyfill@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz#060ee66e85aaedc76b6fa66079782dcc11cba496"
-  integrity sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -4966,11 +4961,6 @@ isomorphic-timers-promises@^1.0.1:
   resolved "https://registry.yarnpkg.com/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz#e4137c24dbc54892de8abae3a4b5c1ffff381598"
   integrity sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==
 
-isomorphic-ws@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
-  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
-
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
@@ -5411,15 +5401,10 @@ magicast@^0.5.1:
     "@babel/types" "^7.28.5"
     source-map-js "^1.2.1"
 
-mailpit-api@^1.2.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/mailpit-api/-/mailpit-api-1.8.1.tgz#2996b936db39440358aa87c4eb25b8a95853e3a6"
-  integrity sha512-nLbgP6cXIFS8U2DN6vDI3z13x1+6T198kVsX/jNwf1L6KEGJkRFCauh/pLxiW5DQoWHmVeOTLQ4scRma40uZRQ==
-  dependencies:
-    axios "^1.13.5"
-    isomorphic-ws "^5.0.0"
-    partysocket "^1.1.10"
-    ws "^8.18.3"
+mailpit-api@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mailpit-api/-/mailpit-api-2.0.0.tgz#f922eaf7e06209b4b2b0ef7d367da0ce8eb1aec8"
+  integrity sha512-zK68B0CRVZaJS1PaX7omFhKUKSLp4JMMpAUTRYbCmcrgJ9nguIh4sS+RRUyFeW1nykDNH8PVlRz/WSXsq9ZqlQ==
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -5917,13 +5902,6 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-partysocket@^1.1.10:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/partysocket/-/partysocket-1.1.16.tgz#0c8894b8a1f370c5975bce26a1c7ceff36b0aec0"
-  integrity sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==
-  dependencies:
-    event-target-polyfill "^0.0.4"
 
 patch-package@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
This is part of my mission to improve the way we handle toasts in our Playwright tests. See also:

* https://github.com/element-hq/element-web/pull/33119
* https://github.com/element-hq/element-web/pull/33158
* https://github.com/element-hq/element-web/pull/33025
* https://github.com/element-hq/element-web/pull/33152
* https://github.com/element-hq/element-web/pull/33500
* https://github.com/element-hq/element-web/pull/33495
* https://github.com/element-hq/element-modules/pull/256
* https://github.com/element-hq/element-modules/pull/252
* https://github.com/element-hq/element-modules/pull/261

This PR also bumps element-web-playwright-common to 4.1.0