### PR TITLE
README.md: remove reference to non-existent `packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,5 @@ See README files in each module for more information.
 
 ## Structure
 
-The `packages` directory holds useful packages related to Element modules, e.g. the module API itself.
 The `modules` directory holds the actual modules, with a directory per module,
 each containing the components as appropriate, e.g. `element-web` & `synapse`.


### PR DESCRIPTION
There is no `packages` directory.