### PR TITLE
Monkey-patch the room directory away from guests

### DIFF
--- a/modules/restricted-guests/synapse/README.md
+++ b/modules/restricted-guests/synapse/README.md
@@ -10,6 +10,12 @@ A [pluggable synapse module](https://element-hq.github.io/synapse/latest/modules
 4. The temporary users won't be returned by the user directory search results, and the temporary users themselves get an empty user directory: they should not be handed a browsable index of users they have no relationship with.
 5. The temporary users are disabled after an expiration timeout (default: `24 hours`).
 
+## Compatibility
+
+This module requires Synapse 1.122.0 or later: the first release that tells the user directory spam checker who is searching, which the module needs to give guests an empty directory. On anything older, user directory searches fail with an internal error once the module is loaded.
+
+Gating the room directory (`hide_room_directory_from_guests`) is opt-in and disabled by default because it monkey-patches Synapse's internal `RoomListHandler`; Synapse has no module callback there. The patch was verified against Synapse 1.159, and the test suite re-verifies the patched internals against the installed Synapse. The module refuses to start if the methods it replaces have been renamed or re-shaped, but it cannot tell when a future Synapse stops recording the caller's user ID on the request's logging context: guests would then silently see the full room directory again. Do not rely on this option as the only control. Guests receive the same empty response Synapse serves when `enable_room_list_search` is disabled.
+
 ## Synapse configuration
 
 This modules requires that the homeserver has the following configuration in their `homeserver.yaml`:
@@ -21,6 +27,8 @@ This modules requires that the homeserver has the following configuration in the
 # flow it enables does not exist.
 allow_guest_access: true
 ```
+
+If `hide_room_directory_from_guests` is enabled, `allow_public_rooms_without_auth` must be left at its default of `false`. With it enabled the room directory is readable without an access token and therefore cannot be gated per-user, and the module refuses to start.
 
 ## Module installation
 
@@ -43,6 +51,10 @@ The module provides (optional) configuration options:
 - `display_name_suffix` - the suffix added to the display name of guest users. Default: ` (Guest)`.
 - `enable_user_reaper` - if true, the module disables all users that are older than the configured expiration time. Default: `true`.
 - `user_expiration_seconds` - the expiration time in seconds when a guest user expires after their creation. Default: `86400` (=24 hours).
+- `hide_room_directory_from_guests` - if true, guests get an empty public room directory, including the `?server=` proxy to remote directories. Default: `false`.
+
+    This option monkey-patches Synapse internals (see [Compatibility](#compatibility)) and can silently stop working on a future Synapse. Deployments that leave it off can set `enable_room_list_search: false` in `homeserver.yaml` instead, which hides the directory from every user.
+
 - `rooms_forbidden_to_guests` - room IDs (not aliases — the module refuses aliases at startup) that guests must never be a member of, for example a hidden room that every user is auto-joined to. Guests are refused a join to these rooms even when they have been invited, and invites of guests into them are rejected. Default: `[]`.
 
     This matters because membership of a room exposes its full member list over `/rooms/{roomId}/members`: a guest in a server-wide room can enumerate every user on the server, which is what hiding the user directory from guests is there to prevent. The join refusal is what enforces it — server admins bypass the invite check.
@@ -69,6 +81,8 @@ modules:
       config:
           # Use a german suffix
           display_name_suffix: " (Gast)"
+          # Hide the public room directory from guests (opt-in, see Compatibility)
+          hide_room_directory_from_guests: true
           # Guests may never join these rooms, invited or not
           rooms_forbidden_to_guests:
               - "!allUsers:example.org"

--- a/modules/restricted-guests/synapse/setup.cfg
+++ b/modules/restricted-guests/synapse/setup.cfg
@@ -25,6 +25,8 @@ synapse_guest_module = py.typed
 [options.extras_require]
 dev =
   # for tests
+  # Unpinned so tests run against the newest Synapse: the compatibility
+  # canary in tests/test_room_list_patch.py needs to see new releases.
   matrix-synapse
   tox
   twisted
@@ -33,7 +35,6 @@ dev =
   parameterized
   # for type checking
   mypy == 1.10.0
-  pydantic == 2.4.2
   # for linting
   black == 22.3.0
   flake8 == 4.0.1

--- a/modules/restricted-guests/synapse/synapse_guest_module/config.py
+++ b/modules/restricted-guests/synapse/synapse_guest_module/config.py
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2023 Nordeck IT + Consulting GmbH
 # Copyright 2025 New Vector Ltd.
 #
@@ -28,6 +29,9 @@ class GuestModuleConfig:
     enable_user_reaper: bool
     user_expiration_seconds: int
     mas: Optional[MasConfig] = None
+    # Whether to monkey-patch RoomListHandler so guests get an empty room directory;
+    # see room_list_patch.py for why this defaults to false.
+    hide_room_directory_from_guests: bool = False
     # Rooms guests must never be members of, such as an auto-join announcements room.
     # Membership exposes the room's full member list over `/rooms/{roomId}/members`, so
     # a guest in a server-wide room can enumerate every user — what hiding the user

--- a/modules/restricted-guests/synapse/synapse_guest_module/guest_module.py
+++ b/modules/restricted-guests/synapse/synapse_guest_module/guest_module.py
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2023 Nordeck IT + Consulting GmbH
 # Copyright 2025 New Vector Ltd.
 #
@@ -27,6 +28,7 @@ from synapse_guest_module.config import GuestModuleConfig, MasConfig
 from synapse_guest_module.guest_registration_servlet import GuestRegistrationServlet
 from synapse_guest_module.guest_user_reaper import GuestUserReaper
 from synapse_guest_module.mas_admin_client import MasAdminClient
+from synapse_guest_module.room_list_patch import patch_room_list_handler
 
 logger = logging.getLogger("synapse.contrib." + __name__)
 
@@ -36,6 +38,9 @@ class GuestModule:
         self._api = api
         self._config = config
         self._mas_tables_ready: asyncio.Event | None = None
+
+        if config.hide_room_directory_from_guests:
+            patch_room_list_handler(api, self._is_module_guest)
 
         mas_admin_client = (
             MasAdminClient(api, config.mas) if config.mas is not None else None
@@ -109,6 +114,14 @@ class GuestModule:
         if not isinstance(user_expiration_seconds, int):
             raise ConfigError(
                 "Config option 'user_expiration_seconds' must be a number"
+            )
+
+        hide_room_directory_from_guests = config.get(
+            "hide_room_directory_from_guests", False
+        )
+        if not isinstance(hide_room_directory_from_guests, bool):
+            raise ConfigError(
+                "Config option 'hide_room_directory_from_guests' must be a bool"
             )
 
         rooms_forbidden_to_guests = config.get("rooms_forbidden_to_guests", [])
@@ -198,6 +211,7 @@ class GuestModule:
             enable_user_reaper,
             user_expiration_seconds,
             mas,
+            hide_room_directory_from_guests,
             frozenset(rooms_forbidden_to_guests),
         )
 

--- a/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
+++ b/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
@@ -9,10 +9,12 @@ import logging
 from typing import Any, Callable, Coroutine
 
 import attr
+
+# The logging context is not part of the module API surface; reading the requester
+# from it is the same private-internals reach as the patch itself.
 from synapse.logging.context import ContextRequest, current_context
-from synapse.module_api import ModuleApi
+from synapse.module_api import JsonDict, ModuleApi, UserID
 from synapse.module_api.errors import ConfigError, SynapseError
-from synapse.types import JsonDict, UserID
 
 logger = logging.getLogger("synapse.contrib." + __name__)
 

--- a/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
+++ b/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Element Creations Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the project root for full details.
+
+import functools
+import inspect
+import logging
+from typing import Any, Callable, Coroutine
+
+import attr
+from synapse.logging.context import ContextRequest, current_context
+from synapse.module_api import ModuleApi
+from synapse.module_api.errors import ConfigError, SynapseError
+from synapse.types import JsonDict, UserID
+
+logger = logging.getLogger("synapse.contrib." + __name__)
+
+RoomListMethod = Callable[..., Coroutine[Any, Any, JsonDict]]
+
+# `ResponseCache` memoises the inner `_get_public_room_list`, so on a cache hit the
+# inner call ran in the first caller's logging context. Only these outer methods are
+# guaranteed to run in the context of the request being served.
+PATCHED_METHODS = ("get_local_public_room_list", "get_remote_public_room_list")
+
+_PATCH_MARKER = "_guest_module_room_list_patched"
+
+
+def _requester_is_guest(is_module_guest: Callable[[str], bool]) -> bool:
+    """Whether the request being served belongs to a guest managed by this module.
+
+    `PublicRoomListRestServlet` authenticates the request but does not pass the
+    `Requester` to the handler. The `SynapseRequest.requester` setter copies the MXID
+    into `logcontext.request.requester` before the servlet runs, so the logging
+    context still identifies the caller.
+    """
+    request = current_context().request
+    # The sentinel context: anything not serving an HTTP request, such as background
+    # jobs and startup. No guest is waiting on the result, so pass it through.
+    if request is None:
+        return False
+
+    # `requester` holds a bare server name for inbound federation and `None` for
+    # unauthenticated requests; neither can be a local guest.
+    requester = request.requester
+    if not isinstance(requester, str) or not requester.startswith("@"):
+        return False
+
+    try:
+        UserID.from_string(requester)
+    except SynapseError:
+        # Not a parsable user ID, so not one of ours.
+        return False
+
+    # Match only guests this module created. /publicRooms allows native Synapse
+    # guests (allow_guest=True); those pass through, and the login flow that creates
+    # them does not exist under MAS.
+    return is_module_guest(requester)
+
+
+def _guard(
+    original: RoomListMethod, is_module_guest: Callable[[str], bool]
+) -> RoomListMethod:
+    @functools.wraps(original)
+    async def wrapper(*args: Any, **kwargs: Any) -> JsonDict:
+        if _requester_is_guest(is_module_guest):
+            # What Synapse serves when enable_room_list_search is disabled. A persistent
+            # 403 sends Element X Android into a retry loop instead of an empty state.
+            return {"chunk": [], "total_room_count_estimate": 0}
+
+        return await original(*args, **kwargs)
+
+    setattr(wrapper, _PATCH_MARKER, True)
+    return wrapper
+
+
+def patch_room_list_handler(
+    api: ModuleApi, is_module_guest: Callable[[str], bool]
+) -> None:
+    """Make the room directory look empty to guests.
+
+    Synapse offers no module callback on the room list, so this reassigns private
+    internals, verified against Synapse 1.159.
+
+    The checks below catch a renamed or re-shaped `RoomListHandler` and a
+    `ContextRequest` that has lost its `requester` field. They cannot catch
+    `SynapseRequest.requester` no longer writing the MXID into that field before the
+    servlet runs, nor it writing something that is not an MXID string: both leave the
+    field present but empty, and both fail open.
+    """
+    hs = api._hs
+
+    if hs.config.server.allow_public_rooms_without_auth:
+        raise ConfigError(
+            "The guest module requires 'allow_public_rooms_without_auth' to be false: "
+            "the room directory is otherwise served without an access token, leaving "
+            "no requester to hide it from"
+        )
+
+    if not any(field.name == "requester" for field in attr.fields(ContextRequest)):
+        raise ConfigError(
+            "This version of Synapse is not supported by the guest module: the logging "
+            "context request has no 'requester' field"
+        )
+
+    handler = hs.get_room_list_handler()
+    for name in PATCHED_METHODS:
+        if not inspect.iscoroutinefunction(getattr(handler, name, None)):
+            raise ConfigError(
+                "This version of Synapse is not supported by the guest module: "
+                f"RoomListHandler.{name} is missing or is not a coroutine function"
+            )
+
+    for name in PATCHED_METHODS:
+        original = getattr(handler, name)
+        if getattr(original, _PATCH_MARKER, False):
+            # A second module instance in the same process would otherwise stack
+            # another wrapper on the first one's.
+            logger.warning(
+                "RoomListHandler.%s is already patched by another module instance; "
+                "keeping that wrapper",
+                name,
+            )
+            continue
+        setattr(handler, name, _guard(original, is_module_guest))
+
+    logger.warning(
+        "Patched RoomListHandler.{%s} to hide the room directory from guests",
+        ", ".join(PATCHED_METHODS),
+    )

--- a/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
+++ b/modules/restricted-guests/synapse/synapse_guest_module/room_list_patch.py
@@ -10,8 +10,7 @@ from typing import Any, Callable, Coroutine
 
 import attr
 
-# The logging context is not part of the module API surface; reading the requester
-# from it is the same private-internals reach as the patch itself.
+# Not re-exported by synapse.module_api.
 from synapse.logging.context import ContextRequest, current_context
 from synapse.module_api import JsonDict, ModuleApi, UserID
 from synapse.module_api.errors import ConfigError, SynapseError

--- a/modules/restricted-guests/synapse/tests/__init__.py
+++ b/modules/restricted-guests/synapse/tests/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2023 Nordeck IT + Consulting GmbH
 # Copyright 2025 New Vector Ltd.
 #
@@ -9,7 +10,7 @@
 
 import sqlite3
 from asyncio import Future
-from typing import Any, Awaitable, Callable, Dict, Tuple, TypeVar, Union
+from typing import Any, Awaitable, Callable, Dict, List, Tuple, TypeVar, Union
 from unittest.mock import Mock
 
 from synapse.http.client import SimpleHttpClient
@@ -104,6 +105,48 @@ async def register_user(localpart: str, admin: bool = False) -> str:
     return f"@{localpart}:matrix.local"
 
 
+class StubRoomListHandler:
+    """Stand-in for Synapse's `RoomListHandler`.
+
+    `patch_room_list_handler` only reaches for the two methods it replaces, and requires
+    them to be coroutine functions.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Tuple[Any, ...], Dict[str, Any]]] = []
+        self.result: Dict[str, Any] = {
+            "chunk": [{"room_id": "!room:matrix.local"}],
+            "total_room_count_estimate": 1,
+        }
+
+    async def get_local_public_room_list(
+        self, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        self.calls.append(("get_local_public_room_list", args, kwargs))
+        return self.result
+
+    async def get_remote_public_room_list(
+        self, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        self.calls.append(("get_remote_public_room_list", args, kwargs))
+        return self.result
+
+
+def stub_homeserver(
+    handler: Any = None,
+    allow_public_rooms_without_auth: bool = False,
+) -> Mock:
+    """A stub for `ModuleApi._hs`, which `Mock(spec=ModuleApi)` does not provide because
+    it is an instance attribute.
+    """
+    hs = Mock()
+    hs.config.server.allow_public_rooms_without_auth = allow_public_rooms_without_auth
+    hs.get_room_list_handler.return_value = (
+        StubRoomListHandler() if handler is None else handler
+    )
+    return hs
+
+
 def create_module(
     config_override: Dict[str, Any] | None = None,
 ) -> Tuple[GuestModule, Mock, SQLiteStore]:
@@ -116,6 +159,7 @@ def create_module(
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
     module_api = Mock(spec=ModuleApi)
+    module_api._hs = stub_homeserver()
     module_api.http_client = client
     module_api.server_name = SERVER_NAME
     module_api.public_baseurl = "https://matrix.local:1234/"

--- a/modules/restricted-guests/synapse/tests/test_guest_module.py
+++ b/modules/restricted-guests/synapse/tests/test_guest_module.py
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2023 Nordeck IT + Consulting GmbH
 # Copyright 2025 New Vector Ltd.
 #
@@ -116,6 +117,17 @@ class GuestModuleConfigTest(aiounittest.AsyncTestCase):
             GuestModule.parse_config(
                 {
                     "enable_user_reaper": "False",
+                }
+            )
+
+    async def test_parse_config_fail_hide_room_directory_from_guests(self) -> None:
+        with self.assertRaisesRegex(
+            ConfigError,
+            "Config option 'hide_room_directory_from_guests' must be a bool",
+        ):
+            GuestModule.parse_config(
+                {
+                    "hide_room_directory_from_guests": "False",
                 }
             )
 

--- a/modules/restricted-guests/synapse/tests/test_room_list_patch.py
+++ b/modules/restricted-guests/synapse/tests/test_room_list_patch.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Element Creations Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the project root for full details.
+
+import inspect
+from typing import Any, Dict, Optional
+from unittest.mock import Mock
+
+import aiounittest
+import attr
+from synapse.logging.context import ContextRequest, LoggingContext
+from synapse.module_api import ModuleApi
+from synapse.module_api.errors import ConfigError
+from synapse.types import UserID
+
+from synapse_guest_module.room_list_patch import (
+    PATCHED_METHODS,
+    patch_room_list_handler,
+)
+from tests import StubRoomListHandler, create_module, stub_homeserver
+
+SERVER_NAME = "matrix.local"
+GUEST = "@guest-abc:matrix.local"
+USER = "@alice:matrix.local"
+REMOTE_GUEST = "@guest-abc:other.example"
+EMPTY_ROOM_LIST = {"chunk": [], "total_room_count_estimate": 0}
+
+
+def is_guest(user_id: str) -> bool:
+    user = UserID.from_string(user_id)
+    return user.domain == SERVER_NAME and user.localpart.startswith("guest-")
+
+
+def logging_context(requester: Optional[str]) -> LoggingContext:
+    request = ContextRequest(
+        request_id="req-1",
+        ip_address="1.2.3.4",
+        site_tag="test",
+        requester=requester,
+        authenticated_entity=requester,
+        method="GET",
+        url="/_matrix/client/v3/publicRooms",
+        protocol="1.1",
+        user_agent="test",
+    )
+    return LoggingContext(name="test", server_name=SERVER_NAME, request=request)
+
+
+def patched_handler(
+    handler: Any = None,
+    allow_public_rooms_without_auth: bool = False,
+) -> Any:
+    api = Mock(spec=ModuleApi)
+    api._hs = stub_homeserver(handler, allow_public_rooms_without_auth)
+    patch_room_list_handler(api, is_guest)
+    return api._hs.get_room_list_handler()
+
+
+class RoomListPatchTest(aiounittest.AsyncTestCase):
+    async def test_guest_gets_an_empty_local_room_list(self) -> None:
+        handler = patched_handler()
+
+        with logging_context(GUEST):
+            result = await handler.get_local_public_room_list(limit=10)
+
+        self.assertEqual(result, EMPTY_ROOM_LIST)
+        self.assertEqual(handler.calls, [])
+
+    async def test_guest_gets_an_empty_remote_room_list(self) -> None:
+        handler = patched_handler()
+
+        with logging_context(GUEST):
+            result = await handler.get_remote_public_room_list("other.example")
+
+        self.assertEqual(result, EMPTY_ROOM_LIST)
+        self.assertEqual(handler.calls, [])
+
+    async def test_the_empty_room_list_is_not_shared_between_requests(self) -> None:
+        """Guards against returning a shared module-level literal a caller could
+        mutate."""
+        handler = patched_handler()
+
+        with logging_context(GUEST):
+            first = await handler.get_local_public_room_list()
+            first["chunk"].append("mutated")
+            second = await handler.get_local_public_room_list()
+
+        self.assertEqual(second, EMPTY_ROOM_LIST)
+
+    async def test_ordinary_user_is_passed_through(self) -> None:
+        handler = patched_handler()
+
+        with logging_context(USER):
+            result = await handler.get_local_public_room_list(
+                10, "since-token", search_filter={"generic_search_term": "a"}
+            )
+
+        self.assertIs(result, handler.result)
+        self.assertEqual(
+            handler.calls,
+            [
+                (
+                    "get_local_public_room_list",
+                    (10, "since-token"),
+                    {"search_filter": {"generic_search_term": "a"}},
+                )
+            ],
+        )
+
+    async def test_the_sentinel_context_is_passed_through(self) -> None:
+        """Background jobs run outside any request context."""
+        handler = patched_handler()
+
+        result = await handler.get_local_public_room_list()
+
+        self.assertIs(result, handler.result)
+
+    async def test_federation_origin_is_passed_through(self) -> None:
+        handler = patched_handler()
+
+        with logging_context("other.example"):
+            result = await handler.get_local_public_room_list()
+
+        self.assertIs(result, handler.result)
+
+    async def test_unauthenticated_request_is_passed_through(self) -> None:
+        handler = patched_handler()
+
+        with logging_context(None):
+            result = await handler.get_local_public_room_list()
+
+        self.assertIs(result, handler.result)
+
+    async def test_unparsable_requester_is_passed_through(self) -> None:
+        handler = patched_handler()
+
+        with logging_context("@not-a-user-id"):
+            result = await handler.get_local_public_room_list()
+
+        self.assertIs(result, handler.result)
+
+    async def test_remote_guest_is_passed_through(self) -> None:
+        handler = patched_handler()
+
+        with logging_context(REMOTE_GUEST):
+            result = await handler.get_local_public_room_list()
+
+        self.assertIs(result, handler.result)
+
+    async def test_patching_twice_does_not_stack_wrappers(self) -> None:
+        handler = StubRoomListHandler()
+        patched_handler(handler)
+        patched_handler(handler)
+
+        with logging_context(GUEST):
+            empty = await handler.get_local_public_room_list()
+
+        with logging_context(USER):
+            passed_through = await handler.get_local_public_room_list()
+
+        self.assertEqual(empty, EMPTY_ROOM_LIST)
+        self.assertIs(passed_through, handler.result)
+        self.assertEqual(len(handler.calls), 1)
+        # Unwrapping once reaches the stub itself, so only one wrapper was installed.
+        wrapper = handler.__dict__["get_local_public_room_list"]
+        self.assertIs(
+            wrapper.__wrapped__.__func__,
+            StubRoomListHandler.get_local_public_room_list,
+        )
+
+    async def test_refuses_allow_public_rooms_without_auth(self) -> None:
+        with self.assertRaises(ConfigError):
+            patched_handler(allow_public_rooms_without_auth=True)
+
+    async def test_nothing_is_patched_when_public_rooms_are_unauthenticated(
+        self,
+    ) -> None:
+        handler = StubRoomListHandler()
+
+        with self.assertRaises(ConfigError):
+            patched_handler(handler, allow_public_rooms_without_auth=True)
+
+        self.assertNotIn("get_local_public_room_list", handler.__dict__)
+
+    async def test_refuses_a_handler_missing_a_method(self) -> None:
+        class HandlerWithoutRemote:
+            async def get_local_public_room_list(self) -> Dict[str, Any]:
+                return {}
+
+        with self.assertRaises(ConfigError):
+            patched_handler(HandlerWithoutRemote())
+
+    async def test_refuses_a_method_that_is_not_a_coroutine_function(self) -> None:
+        class SyncHandler(StubRoomListHandler):
+            def get_remote_public_room_list(  # type: ignore[override]
+                self, *args: Any, **kwargs: Any
+            ) -> Dict[str, Any]:
+                return {}
+
+        with self.assertRaises(ConfigError):
+            patched_handler(SyncHandler())
+
+    async def test_nothing_is_patched_when_a_method_is_unsupported(self) -> None:
+        class SyncHandler(StubRoomListHandler):
+            def get_remote_public_room_list(  # type: ignore[override]
+                self, *args: Any, **kwargs: Any
+            ) -> Dict[str, Any]:
+                return {}
+
+        handler = SyncHandler()
+
+        with self.assertRaises(ConfigError):
+            patched_handler(handler)
+
+        # The patcher installs wrappers as instance attributes.
+        self.assertNotIn("get_local_public_room_list", handler.__dict__)
+
+    async def test_the_patched_internals_still_exist_in_the_installed_synapse(
+        self,
+    ) -> None:
+        """Fails in CI when the installed Synapse moves the internals the patch
+        replaces."""
+        from synapse.handlers.room_list import RoomListHandler
+
+        for name in PATCHED_METHODS:
+            self.assertTrue(
+                inspect.iscoroutinefunction(getattr(RoomListHandler, name, None)),
+                f"RoomListHandler.{name}",
+            )
+        self.assertIn("requester", attr.fields_dict(ContextRequest))
+
+
+class GuestModuleRoomListPatchWiringTest(aiounittest.AsyncTestCase):
+    """Checks that `GuestModule.__init__` applies the patch. `RoomListPatchTest`
+    covers the patch's behaviour."""
+
+    async def test_patched_when_hide_room_directory_from_guests_is_enabled(
+        self,
+    ) -> None:
+        _, module_api, _ = create_module({"hide_room_directory_from_guests": True})
+
+        handler = module_api._hs.get_room_list_handler()
+        self.assertIn("get_local_public_room_list", handler.__dict__)
+
+    async def test_not_patched_by_default(self) -> None:
+        _, module_api, _ = create_module()
+
+        handler = module_api._hs.get_room_list_handler()
+        self.assertNotIn("get_local_public_room_list", handler.__dict__)

--- a/modules/restricted-guests/synapse/tests/test_room_list_patch.py
+++ b/modules/restricted-guests/synapse/tests/test_room_list_patch.py
@@ -10,9 +10,8 @@ from unittest.mock import Mock
 import aiounittest
 import attr
 from synapse.logging.context import ContextRequest, LoggingContext
-from synapse.module_api import ModuleApi
+from synapse.module_api import ModuleApi, UserID
 from synapse.module_api.errors import ConfigError
-from synapse.types import UserID
 
 from synapse_guest_module.room_list_patch import (
     PATCHED_METHODS,


### PR DESCRIPTION
Part of the [restricted-guests work](https://github.com/element-hq/backend-internal/issues/287): guests must not get a browsable index of rooms, matching the empty user directory they already get.

Synapse has no module callback on the public room directory, so this monkey-patches `RoomListHandler.get_local_public_room_list` / `get_remote_public_room_list` and reads the requester back from the request's logging context, where `SynapseRequest.requester` stores it before the servlet runs. The option is opt-in and off by default because the patch reaches into private internals and can fail open on a future Synapse (see the README's Compatibility section). The module refuses to start when the internals have visibly moved, and a canary test re-verifies them against the Synapse release CI installs.

Guests get the same empty response Synapse serves when `enable_room_list_search` is disabled. A 403 would send Element X Android into a retry loop.

I acknowledge that monkey-patching isn't particularly pretty and we could have some of this done by say the SBG– but having talked to Andrew and Olivier about it, looks like this is the most sensible way to go with considering the short-ish timeline; and I plan to have some regression E2E tests in the ESS Pro repo once this lands.